### PR TITLE
feat: expose CNPG PostgreSQL via TCPRoute on Envoy Gateway

### DIFF
--- a/base/envoy-gateway/manifests/gateway.yaml
+++ b/base/envoy-gateway/manifests/gateway.yaml
@@ -27,3 +27,9 @@ spec:
             kind: Secret
             name: wildcard-tls
             namespace: envoy-gateway-system
+    - name: tcp-postgres
+      protocol: TCP
+      port: 5432
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/overlays/pelindung-bumi/prod/cnpg/app.yaml
+++ b/overlays/pelindung-bumi/prod/cnpg/app.yaml
@@ -14,3 +14,6 @@ sources:
   - repoURL: https://github.com/pelindung-bumi/galaksi
     targetRevision: HEAD
     ref: values
+  - repoURL: https://github.com/pelindung-bumi/galaksi
+    targetRevision: HEAD
+    path: overlays/pelindung-bumi/prod/cnpg/manifests

--- a/overlays/pelindung-bumi/prod/cnpg/manifests/kustomization.yaml
+++ b/overlays/pelindung-bumi/prod/cnpg/manifests/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tcproute.yaml

--- a/overlays/pelindung-bumi/prod/cnpg/manifests/tcproute.yaml
+++ b/overlays/pelindung-bumi/prod/cnpg/manifests/tcproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tofu-state-postgres
+  namespace: cnpg-system
+spec:
+  parentRefs:
+    - name: pelindung-bumi-gateway
+      namespace: envoy-gateway-system
+      sectionName: tcp-postgres
+  rules:
+    - backendRefs:
+        - name: tofu-state-rw
+          namespace: cnpg-system
+          port: 5432

--- a/overlays/pelindung-bumi/prod/envoy-gateway/manifests/patch-envoyproxy.yaml
+++ b/overlays/pelindung-bumi/prod/envoy-gateway/manifests/patch-envoyproxy.yaml
@@ -24,3 +24,8 @@ spec:
                   port: 30443
                   protocol: TCP
                   targetPort: 30443
+                - name: tcp-postgres
+                  nodePort: 30432
+                  port: 30432
+                  protocol: TCP
+                  targetPort: 30432

--- a/overlays/pelindung-bumi/prod/envoy-gateway/manifests/patch-gateway.yaml
+++ b/overlays/pelindung-bumi/prod/envoy-gateway/manifests/patch-gateway.yaml
@@ -26,3 +26,9 @@ spec:
             kind: Secret
             name: wildcard-tls
             namespace: envoy-gateway-system
+    - name: tcp-postgres
+      protocol: TCP
+      port: 30432
+      allowedRoutes:
+        namespaces:
+          from: All


### PR DESCRIPTION
Add TCP listener (port 30432) to the Gateway and EnvoyProxy for PostgreSQL access without kubectl port-forward. Create a TCPRoute in the cnpg overlay routing to tofu-state-rw:5432 service.